### PR TITLE
Fix -g1 compilation where extra labels are created due to an off by 1

### DIFF
--- a/gas/config/tc-mips.c
+++ b/gas/config/tc-mips.c
@@ -6666,6 +6666,7 @@ s_mipsset (x)
 	*input_line_pointer = ch;
 	input_line_pointer = name;
 	s_set(x);
+	return;
     }
   *input_line_pointer = ch;
   demand_empty_rest_of_line ();


### PR DESCRIPTION
When compiling with -g1 from the 2.7.2 compiler, this assembler fails to properly handle .set commands resulting in going to the end of the line then replacing the first character on the next line with a newline. When the next line is a label it destroys the first character of the label. Adding a return prevents this as the s_set already set the input_line_pointer to the end of the line as needed.

This is inline with what the kmc compiler was doing and can be observed by compiling with -g1 to a .o file then using readelf -s to view the listed symbols.