### PR TITLE
Report an error if was not able to open asm file

### DIFF
--- a/gas/input-file.c
+++ b/gas/input-file.c
@@ -152,6 +152,11 @@ char* read_asm(const char *pathname, size_t* output_size) {
     char cur_insn_first_char;
 
     fd = fopen(pathname, "r");
+    if (fd == NULL)
+    {
+        as_fatal ("Can't open %s for reading.", pathname);
+    }
+
     fseek(fd, 0, SEEK_END);
     input_size = ftell(fd);
     initial_output_size = input_size;


### PR DESCRIPTION
Prevents the `gcc: Internal compiler error: program as got fatal signal 11` error when trying to open non-existing files on `INCLUDE_ASM`