### PR TITLE
Replaced incorrect memcpy usage with memmove in tc-mips.c

### DIFF
--- a/gas/config/tc-mips.c
+++ b/gas/config/tc-mips.c
@@ -7294,7 +7294,7 @@ md_convert_frag (abfd, asec, fragp)
   fixptr = fragp->fr_literal + fragp->fr_fix;
 
   if (new > 0)
-    memcpy (fixptr - old, fixptr, new);
+    memmove (fixptr - old, fixptr, new);
 
   fragp->fr_fix += new - old;
 }


### PR DESCRIPTION
Fixes a potential issue where incorrect instructions are written out.