### PR TITLE
Add `c++filt` to packaged programs on releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,15 +56,18 @@ jobs:
           cp gas/as.new as
           cp binutils/strip.new strip
           cp binutils/objcopy objcopy
+          cp binutils/c++filt c++filt
           strip ar
           strip as
           strip strip
           strip objcopy
+          strip c++filt
           chmod +x ar
           chmod +x as
           chmod +x strip
           chmod +x objcopy
-          tar -czf ${{ matrix.TARGET.ARCHIVE_NAME }} ar as strip objcopy
+          chmod +x c++filt
+          tar -czf ${{ matrix.TARGET.ARCHIVE_NAME }} ar as strip objcopy c++filt
       - name: Upload archive
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Recently I was told IDO has a C++ frontend, which uses a name mangling scheme which is not recognized by any of the elf modern tools.

After a few days of being interested on how it works, but not really wanting to decomp said frontend just for this, I ended up investigating more about mangling, and noticed the [Wikipedia article](https://en.wikipedia.org/wiki/Name_mangling#How_different_compilers_mangle_the_same_functions) shows the GCC 2.9.X format is very similar to what IDO does for the mangling.

Sadly modern binutils does not support said format anymore, but old versions like KMC's `c++filt` does. So instead of forcing anybody to clone the repo and build this themselves I thought it would be a better idea to just provide a prebuilt version of this program on the releases we currently do.