### PR TITLE
Implement o32 elf flag via `-mabi=32` and `-32`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "editor.detectIndentation": false,
+    "editor.indentSize": 2,
+    "editor.tabSize": 8
+}

--- a/include/elf/mips.h
+++ b/include/elf/mips.h
@@ -39,6 +39,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
    position independent code.  */
 #define EF_MIPS_CPIC		0x00000004
 
+/* Code in file uses new ABI (-n32 on Irix 6).  */
+#define EF_MIPS_ABI2		0x00000020
+
 /* Four bit MIPS architecture field.  */
 #define EF_MIPS_ARCH		0xf0000000
 
@@ -50,6 +53,23 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
 
 /* -mips3 code.  */
 #define E_MIPS_ARCH_3		0x20000000
+
+
+/* The ABI of the file.  Also see EF_MIPS_ABI2 above. */
+#define EF_MIPS_ABI		0x0000F000
+
+/* The original o32 abi. */
+#define E_MIPS_ABI_O32          0x00001000
+
+/* O32 extended to work on 64 bit architectures */
+#define E_MIPS_ABI_O64          0x00002000
+
+/* EABI in 32 bit mode */
+#define E_MIPS_ABI_EABI32       0x00003000
+
+/* EABI in 64 bit mode */
+#define E_MIPS_ABI_EABI64       0x00004000
+
 
 /* Processor specific section indices.  These sections do not actually
    exist.  Symbols with a st_shndx field corresponding to one of these


### PR DESCRIPTION
Implements gas setting the `o32` bit flag on the generated elf.

This is desired because lld (clang's linker) will assume an object file uses the `n64` abi unless the `o32` flag is explicitly set, which is a wrong assumption, but it is simpler to implement here compared to fixing it on lld side.

By default gas won't set the `o32` flag to preserve the original behavior. To tell gas to use said flag then either the `-mabi=32` or `-32` args must be passed to gas.

The specific implementation was stolen from modern binutils.