### PR TITLE
Add `--n64align` flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/gas/as.c
+++ b/gas/as.c
@@ -115,7 +115,7 @@ Options:\n\
 --statistics		print maximum bytes and total seconds used\n\
 --version		print assembler version number and exit\n\
 -V, --vr4300mul-off	turn off vr4300 mulmul fix\n\
--N, --n64align          enable special alignment for Nintendo 64\n\
+-N, --force-n64align          enable special alignment for Nintendo 64\n\
 -W			suppress warnings\n\
 -w			ignored\n\
 -X			ignored\n\
@@ -220,7 +220,7 @@ common_emul_init ()
  */
 
 extern int vr4300mul_enabled;
-extern int n64align_enabled;
+extern int force_n64align_enabled;
 
 void
 parse_args (pargc, pargv)
@@ -261,7 +261,7 @@ parse_args (pargc, pargv)
     {"help", no_argument, NULL, OPTION_HELP},
     {"mri", no_argument, NULL, 'M'},
     {"vr4300mul-off", no_argument, NULL, 'V'},
-    {"n64align", no_argument, NULL, 'N'},
+    {"force-n64align", no_argument, NULL, 'N'},
 #define OPTION_NOCPP (OPTION_STD_BASE + 1)
     {"nocpp", no_argument, NULL, OPTION_NOCPP},
 #define OPTION_STATISTICS (OPTION_STD_BASE + 2)
@@ -498,7 +498,7 @@ parse_args (pargc, pargv)
 	  break;
 
 	case 'N':
-	  n64align_enabled = 1;
+	  force_n64align_enabled = 1;
 	  break;
 
 	case 'w':

--- a/gas/as.c
+++ b/gas/as.c
@@ -115,6 +115,7 @@ Options:\n\
 --statistics		print maximum bytes and total seconds used\n\
 --version		print assembler version number and exit\n\
 -V, --vr4300mul-off	turn off vr4300 mulmul fix\n\
+-N, --n64align          enable special alignment for Nintendo 64\n\
 -W			suppress warnings\n\
 -w			ignored\n\
 -X			ignored\n\
@@ -219,6 +220,7 @@ common_emul_init ()
  */
 
 extern int vr4300mul_enabled;
+extern int n64align_enabled;
 
 void
 parse_args (pargc, pargv)
@@ -242,7 +244,7 @@ parse_args (pargc, pargv)
       /* -K is not meaningful if .word is not being hacked.  */
       'K',
 #endif
-      'L', 'M', 'R', 'W', 'Z', 'f', 'a', ':', ':', 'D', 'I', ':', 'o', ':',
+      'L', 'M', 'R', 'W', 'Z', 'f', 'a', 'V', 'N', ':', ':', 'D', 'I', ':', 'o', ':',
 #ifndef VMS
       /* -v takes an argument on VMS, so we don't make it a generic
          option.  */
@@ -259,6 +261,7 @@ parse_args (pargc, pargv)
     {"help", no_argument, NULL, OPTION_HELP},
     {"mri", no_argument, NULL, 'M'},
     {"vr4300mul-off", no_argument, NULL, 'V'},
+    {"n64align", no_argument, NULL, 'N'},
 #define OPTION_NOCPP (OPTION_STD_BASE + 1)
     {"nocpp", no_argument, NULL, OPTION_NOCPP},
 #define OPTION_STATISTICS (OPTION_STD_BASE + 2)
@@ -492,6 +495,10 @@ parse_args (pargc, pargv)
 
 	case 'V':
 	  vr4300mul_enabled = 0;
+	  break;
+
+	case 'N':
+	  n64align_enabled = 1;
 	  break;
 
 	case 'w':

--- a/gas/config/obj-elf.c
+++ b/gas/config/obj-elf.c
@@ -203,6 +203,8 @@ elf_file_symbol (s)
     }
 }
 
+int n64align_enabled = 0;
+
 static void
 obj_elf_common (ignore)
      int ignore;
@@ -275,25 +277,32 @@ obj_elf_common (ignore)
 	    }
 	}
       if (size < 0x400)
-        {
-          if (size < 0x10)
-            {
-              n64_extra_align = 0;
-            }
-          else
-            {
-              n64_extra_align = 8;
-            }
-        }
+	{
+	  if (size < 0x10)
+	    {
+	      n64_extra_align = 0;
+	    }
+	  else
+	    {
+	      n64_extra_align = 8;
+	    }
+	}
       else
-        {
-          n64_extra_align = 16;
-        }
+	{
+	  n64_extra_align = 16;
+	}
       if (temp < n64_extra_align)
-        {
-          as_warn("Variable %s would be aligned in KMC GCC (has %d, would have %d)",
-          S_GET_NAME (symbolP), temp, n64_extra_align);
-        }
+	{
+	  if (n64align_enabled)
+	    {
+	      temp = n64_extra_align;
+	    }
+	  else
+	    {
+	      as_warn("Variable %s would be aligned in KMC GCC (has %d, would have %d)",
+	      S_GET_NAME (symbolP), temp, n64_extra_align);
+	    }
+	}
       if (symbolP->local)
 	{
 	  segT old_sec;

--- a/gas/config/obj-elf.c
+++ b/gas/config/obj-elf.c
@@ -203,7 +203,7 @@ elf_file_symbol (s)
     }
 }
 
-int n64align_enabled = 0;
+int force_n64align_enabled = 0;
 
 static void
 obj_elf_common (ignore)
@@ -293,7 +293,7 @@ obj_elf_common (ignore)
 	}
       if (temp < n64_extra_align)
 	{
-	  if (n64align_enabled)
+	  if (force_n64align_enabled)
 	    {
 	      temp = n64_extra_align;
 	    }


### PR DESCRIPTION
This flag turns on the special alignment logic that the original kmc assembler had for n64 games.

I want this flag because there's a libmus file that requires it to match its bss, and since the lib is source available then I would prefer to use this instead of rework the file (its dumb, i know :sweat_smile:  )